### PR TITLE
[Fix] Query for fetching all screenshots

### DIFF
--- a/libs/web/screenshot/data-access/src/lib/+state/screenshot.effects.ts
+++ b/libs/web/screenshot/data-access/src/lib/+state/screenshot.effects.ts
@@ -196,6 +196,7 @@ export class ScreenshotEffects {
               },
             },
             limit: -1,
+            ignoreRange: true
           })
         ).pipe(
           concatMap(async ({ data }) => {


### PR DESCRIPTION
Adds `ignoreRange` to the query options to ensure that all screenshots are fetched, regardless of any range settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted screenshot deletion behavior to enhance functionality.
  
- **Chores**
	- Minor modifications to screenshot retrieval parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->