### PR TITLE
refactor(auth/models): relocate ILoginForm interface

### DIFF
--- a/libs/web/auth/data-access/src/lib/models/login.model.ts
+++ b/libs/web/auth/data-access/src/lib/models/login.model.ts
@@ -1,3 +1,10 @@
+import { FormControl } from '@angular/forms';
+
+export interface ILoginForm {
+  email: FormControl<string | null>;
+  password: FormControl<string | null>;
+}
+
 export interface ICredentials {
   email: string;
   password: string;

--- a/libs/web/auth/ui/src/lib/login-form/login-form.component.ts
+++ b/libs/web/auth/ui/src/lib/login-form/login-form.component.ts
@@ -20,8 +20,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { ICredentials } from '@ever-co/auth-data-access';
-import { ILoginForm } from '../models/login.model';
+import { ICredentials, ILoginForm } from '@ever-co/auth-data-access';
 
 @Component({
   selector: 'lib-login-form',

--- a/libs/web/auth/ui/src/lib/models/login.model.ts
+++ b/libs/web/auth/ui/src/lib/models/login.model.ts
@@ -1,6 +1,0 @@
-import { FormControl } from '@angular/forms';
-
-export interface ILoginForm {
-  email: FormControl<string | null>;
-  password: FormControl<string | null>;
-}


### PR DESCRIPTION
Moved the ILoginForm interface from the auth/ui library to auth/data-access. This centralizes the definition of the login form structure in the data access layer, making it available where needed across different components or services that handle authentication data.

ERP-12

## Description

Please include a summary of the changes and the related issues.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

Please add here videos or images of the previous status

## Current screenshots

Please add here videos or images of the current (new) status
