### PR TITLE
[Feat](auth-ui): Add signup form component

### DIFF
--- a/libs/web/auth/ui/src/lib/signup-form/signup-form.component.html
+++ b/libs/web/auth/ui/src/lib/signup-form/signup-form.component.html
@@ -1,1 +1,104 @@
-<p>signup-form works!</p>
+<form [formGroup]="form" (ngSubmit)="submitForm()" class="signup-form">
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Email</mat-label>
+    <input
+      matInput
+      type="email"
+      formControlName="email"
+      placeholder="Enter your email"
+      autocomplete="email"
+      required
+      aria-label="Email"
+    />
+    @if (emailRequired) {
+      <mat-error>Email is required.</mat-error>
+    }
+    @if (emailInvalid) {
+      <mat-error>Please enter a valid email address.</mat-error>
+    }
+    @if (emailMinLength) {
+      <mat-error>Email must be at least 5 characters.</mat-error>
+    }
+    @if (emailMaxLength) {
+      <mat-error>Email must be at most 50 characters.</mat-error>
+    }
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Password</mat-label>
+    <input
+      matInput
+      [type]="passwordInputType()"
+      formControlName="password"
+      placeholder="Enter your password"
+      autocomplete="current-password"
+      required
+      aria-label="Password"
+    />
+    <button
+      mat-icon-button
+      matSuffix
+      type="button"
+      (click)="togglePasswordVisibility()"
+      [attr.aria-label]="showPassword() ? 'Hide password' : 'Show password'"
+    >
+      <mat-icon>{{
+        showPassword() ? 'visibility' : 'visibility_off'
+      }}</mat-icon>
+    </button>
+    @if (passwordRequired) {
+      <mat-error>Password is required.</mat-error>
+    }
+    @if (passwordMinLength) {
+      <mat-error>Password must be at least 8 characters.</mat-error>
+    }
+    @if (passwordPattern) {
+      <mat-error>
+        Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character.
+      </mat-error>
+    }
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Confirm Password</mat-label>
+    <input
+      matInput
+      [type]="confirmPasswordInputType()"
+      formControlName="confirmPassword"
+      placeholder="Confirm your password"
+      autocomplete="new-password"
+      required
+      aria-label="Confirm Password"
+    />
+    <button
+      mat-icon-button
+      matSuffix
+      type="button"
+      (click)="toggleConfirmPasswordVisibility()"
+      [attr.aria-label]="showConfirmPassword() ? 'Hide password' : 'Show password'"
+    >
+      <mat-icon>{{
+        showConfirmPassword() ? 'visibility' : 'visibility_off'
+      }}</mat-icon>
+    </button>
+    @if (confirmPasswordRequired) {
+      <mat-error>Confirmation is required.</mat-error>
+    }
+    @if (confirmPasswordMismatch) {
+      <mat-error>Passwords do not match.</mat-error>
+    }
+  </mat-form-field>
+
+  <button
+    mat-raised-button
+    color="primary"
+    type="submit"
+    class="mt-4"
+    [disabled]="form.invalid"
+  >
+    Sign Up
+    @if (loading()) {
+      <mat-icon><mat-spinner diameter="16"> </mat-spinner></mat-icon>
+    }
+  </button>
+</form>

--- a/libs/web/auth/ui/src/lib/signup-form/signup-form.component.scss
+++ b/libs/web/auth/ui/src/lib/signup-form/signup-form.component.scss
@@ -1,0 +1,5 @@
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/libs/web/auth/ui/src/lib/signup-form/signup-form.component.ts
+++ b/libs/web/auth/ui/src/lib/signup-form/signup-form.component.ts
@@ -1,12 +1,162 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ICredentials, ILoginForm } from '@ever-co/auth-data-access';
 
 @Component({
   selector: 'lib-signup-form',
-  imports: [],
+  imports: [
+    ReactiveFormsModule,
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatIconModule,
+    MatDividerModule,
+    MatProgressSpinnerModule,
+  ],
   templateUrl: './signup-form.component.html',
   styleUrl: './signup-form.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SignupFormComponent {
+  public readonly loading = input<boolean | null>(false);
+  public readonly submit = output<ICredentials>({ alias: 'signInWithEmail' });
 
+  public readonly form = new FormGroup<ILoginForm & { confirmPassword: FormControl<string | null> }>({
+    email: new FormControl('', [
+      Validators.required,
+      Validators.email,
+      Validators.minLength(5),
+      Validators.maxLength(50),
+    ]),
+    password: new FormControl('', [
+      Validators.required,
+      Validators.minLength(8),
+      Validators.maxLength(50),
+      Validators.pattern(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/
+      ),
+    ]),
+    confirmPassword: new FormControl('', [Validators.required]),
+  }, { validators: [SignupFormComponent.passwordsMatchValidator] });
+
+  public readonly showPassword = signal(false);
+  public readonly showConfirmPassword = signal(false);
+
+  public readonly passwordInputType = computed(() =>
+    this.showPassword() ? 'text' : 'password'
+  );
+
+  public readonly confirmPasswordInputType = computed(() =>
+    this.showConfirmPassword() ? 'text' : 'password'
+  );
+
+  // Form control getters
+  public get email() { return this.form.get('email'); }
+  public get password() { return this.form.get('password'); }
+  public get confirmPassword() { return this.form.get('confirmPassword'); }
+
+  // Email error getters
+  public get emailRequired() {
+    return this.email?.hasError('required') && this.email?.touched;
+  }
+  public get emailInvalid() {
+    return this.email?.hasError('email') && this.email?.touched;
+  }
+  public get emailMinLength() {
+    return this.email?.hasError('minlength') && this.email?.touched;
+  }
+  public get emailMaxLength() {
+    return this.email?.hasError('maxlength') && this.email?.touched;
+  }
+
+  // Password error getters
+  public get passwordRequired() {
+    return this.password?.hasError('required') && this.password?.touched;
+  }
+  public get passwordMinLength() {
+    return this.password?.hasError('minlength') && this.password?.touched;
+  }
+  public get passwordMaxLength() {
+    return this.password?.hasError('maxlength') && this.password?.touched;
+  }
+  public get passwordPattern() {
+    return this.password?.hasError('pattern') && this.password?.touched;
+  }
+
+  // Password strength error details
+  public get passwordStrengthErrors() {
+    if (this.password?.hasError('passwordStrength')) {
+      return this.password.getError('passwordStrength') as {
+        hasUpperCase?: boolean;
+        hasLowerCase?: boolean;
+        hasNumber?: boolean;
+        hasSpecialChar?: boolean;
+      };
+    }
+    return null;
+  }
+
+  // Confirm password error getters
+  public get confirmPasswordRequired() {
+    return this.confirmPassword?.hasError('required') && this.confirmPassword?.touched;
+  }
+  public get confirmPasswordMismatch() {
+    return this.form.hasError('passwordsMismatch') && this.confirmPassword?.touched;
+  }
+
+  /**
+   * Validates that password and confirm password fields match
+   */
+  private static passwordsMatchValidator(control: AbstractControl): ValidationErrors | null {
+    const group = control as FormGroup;
+    const password = group.get('password')?.value;
+    const confirmPassword = group.get('confirmPassword')?.value;
+
+    if (!password || !confirmPassword) {
+      return null; // Let required validator handle empty fields
+    }
+
+    return password === confirmPassword ? null : { passwordsMismatch: true };
+  }
+
+  public togglePasswordVisibility(): void {
+    this.showPassword.update((v) => !v);
+  }
+
+  public toggleConfirmPasswordVisibility(): void {
+    this.showConfirmPassword.update((v) => !v);
+  }
+
+  public submitForm(): void {
+    if (this.form.valid) {
+      const { email, password } = this.form.value as ICredentials;
+      this.submit.emit({ email, password });
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
 }


### PR DESCRIPTION
Implement the signup form UI component.
Includes fields for email, password, and confirm password with validation using Angular Reactive Forms and Validators. Adds password visibility toggles for security and user experience. Includes basic styling for layout and integrates Angular Material components.

## Description

Please include a summary of the changes and the related issues.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

Please add here videos or images of the previous status

## Current screenshots

Please add here videos or images of the current (new) status
