### PR TITLE
[Feat] Integrate Ever Rec uploader

### DIFF
--- a/apps/desktop/src/assets/workers/upload.worker.js
+++ b/apps/desktop/src/assets/workers/upload.worker.js
@@ -50,11 +50,11 @@ class RetryStrategy {
       if (
         retryCount < this.maxRetries &&
         ['ETIMEDOUT', 'ECONNRESET', 'AbortError'].includes(
-          error.code || error.name
+          error.code || error.name,
         )
       ) {
         await new Promise((resolve) =>
-          setTimeout(resolve, this.retryDelay * (retryCount + 1))
+          setTimeout(resolve, this.retryDelay * (retryCount + 1)),
         );
         return this.executeWithRetry(fn, retryCount + 1);
       }
@@ -96,7 +96,7 @@ class UploadManager {
         this.progressNotifier.notifyProgress(
           this.uploadedBytes,
           this.totalSize,
-          id
+          id,
         );
       });
       // Handle stream errors
@@ -153,6 +153,10 @@ class UploadManager {
       headers['Authorization'] = `Bearer ${this.config.token}`;
     }
 
+    if (this.config?.refreshToken) {
+      headers['X-Refresh-Token'] = this.config.refreshToken;
+    }
+
     return this.retryStrategy.executeWithRetry(async () => {
       const response = await fetch(this.config.url, {
         method: this.config?.token ? 'POST' : 'PUT',
@@ -199,7 +203,7 @@ class UploadManagerFactory {
   static create(files, config) {
     const progressNotifier = new ProgressNotifier(
       PROGRESS_THROTTLE,
-      parentPort
+      parentPort,
     );
     const retryStrategy = new RetryStrategy(MAX_RETRIES, RETRY_DELAY);
     return new UploadManager(files, config, progressNotifier, retryStrategy);

--- a/libs/electron/utils/src/lib/services/ever-rec/ever-rec.service.ts
+++ b/libs/electron/utils/src/lib/services/ever-rec/ever-rec.service.ts
@@ -1,0 +1,55 @@
+import { ILoggable, ILogger, IUpload, UploadType } from '@ever-co/shared-utils';
+import { ElectronLogger } from '../logger/electron-logger';
+
+export type EverRecConfig = Pick<IUpload, 'apiUrl' | 'type'>;
+
+/**
+ * Service for generating upload URLs for EverRec.
+ * Encapsulates configuration handling and logging.
+ */
+export class EverRecService implements ILoggable {
+  public readonly logger: ILogger;
+
+  private static readonly DEFAULT_PATH = 'upload/file';
+
+  constructor(logger: ILogger = new ElectronLogger(EverRecService.name)) {
+    this.logger = logger;
+  }
+
+  /**
+   * Retrieves the EverRec upload URL based on the configured API URL.
+   * @param config - Configuration with apiUrl and uploadType.
+   * @returns The full URL or `null` if configuration is invalid.
+   */
+  public getUploadUrl(config?: EverRecConfig): string | null {
+    const effectiveConfig: EverRecConfig = {
+      apiUrl: config?.apiUrl ?? process.env['apiUrl'],
+      type: config?.type ?? UploadType.SCREENSHOT,
+    };
+
+    if (!effectiveConfig.apiUrl) {
+      this.logger.warn('Missing `apiUrl` in configuration.');
+      return null;
+    }
+
+    const uploadTypeCategoryMap: Record<UploadType, string> = {
+      [UploadType.VIDEO]: 'video',
+      [UploadType.SCREENSHOT]: 'image',
+      [UploadType.PHOTO]: 'camshots',
+      [UploadType.AUDIO]: 'soundshots',
+    };
+
+    try {
+      return new URL(
+        `api/v1/${uploadTypeCategoryMap[effectiveConfig.type]}/${EverRecService.DEFAULT_PATH}`,
+        effectiveConfig.apiUrl,
+      ).toString();
+    } catch (error) {
+      this.logger.error(
+        `Failed to construct the upload URL for apiUrl: ${effectiveConfig.apiUrl}`,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return null;
+    }
+  }
+}

--- a/libs/electron/utils/src/lib/services/uploader/models/uploader-strategy.interface.ts
+++ b/libs/electron/utils/src/lib/services/uploader/models/uploader-strategy.interface.ts
@@ -3,6 +3,7 @@ export interface IUploaderConfig {
   tenantId: string | null;
   token: string | null;
   organizationId: string | null;
+  refreshToken?: string;
 }
 
 export interface IUploaderStrategy {

--- a/libs/electron/utils/src/lib/services/uploader/services/audio-uploader.service.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/audio-uploader.service.ts
@@ -1,7 +1,6 @@
 import {
   IAudio,
   IAudioService,
-  IAudioUpload,
   IUpload,
   IUploadDone,
 } from '@ever-co/shared-utils';
@@ -34,18 +33,10 @@ export class AudioUploaderService extends UploaderService<IAudio> {
     }));
   }
 
-  protected override async synchronize({
-    itemId,
-    result,
-  }: IUploadDone): Promise<void> {
+  protected override async synchronize(uploaded: IUploadDone): Promise<void> {
     await Promise.all([
-      this.service.update(itemId, { synced: true }),
-      this.service.saveUpload<IAudioUpload>({
-        id: itemId,
-        remoteUrl: result.fullUrl,
-        remoteId: result.id,
-        uploadedAt: result.recordedAt,
-      }),
+      this.service.update(uploaded.itemId, { synced: true }),
+      this.synchronizeFactory.synchronize(this.context.strategy, uploaded),
     ]);
   }
 }

--- a/libs/electron/utils/src/lib/services/uploader/services/photo-uploader.service.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/photo-uploader.service.ts
@@ -1,7 +1,6 @@
 import {
   IPhoto,
   IPhotoService,
-  IPhotoUpload,
   IUpload,
   IUploadDone,
 } from '@ever-co/shared-utils';
@@ -29,18 +28,10 @@ export class PhotoUploaderService extends UploaderService<IPhoto> {
     }));
   }
 
-  protected override async synchronize({
-    itemId,
-    result,
-  }: IUploadDone): Promise<void> {
+  protected override async synchronize(uploaded: IUploadDone): Promise<void> {
     await Promise.all([
-      this.service.update(itemId, { synced: true }),
-      this.service.saveUpload<IPhotoUpload>({
-        id: itemId,
-        remoteUrl: result.fullUrl,
-        remoteId: result.id,
-        uploadedAt: result.recordedAt,
-      }),
+      this.service.update(uploaded.itemId, { synced: true }),
+      this.synchronizeFactory.synchronize(this.context.strategy, uploaded),
     ]);
   }
 }

--- a/libs/electron/utils/src/lib/services/uploader/services/screenshot-uploader.service.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/screenshot-uploader.service.ts
@@ -31,18 +31,12 @@ export class ScreenshotUploaderService extends UploaderService<IScreenshot> {
     }));
   }
 
-  protected override async synchronize({
-    itemId,
-    result,
-  }: IUploadDone): Promise<void> {
+  protected override async synchronize(uploaded: IUploadDone): Promise<void> {
     await Promise.all([
-      this.service.update(itemId, { synced: true }),
-      this.service.saveUpload<IScreenshotUpload>({
-        id: itemId,
-        remoteUrl: result.fullUrl,
-        remoteId: result.id,
-        uploadedAt: result.recordedAt,
-      }),
+      this.service.update(uploaded.itemId, { synced: true }),
+      this.service.saveUpload<IScreenshotUpload>(
+        this.synchronizeFactory.synchronize(this.context.strategy, uploaded),
+      ),
     ]);
   }
 

--- a/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/default-response.handler.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/default-response.handler.ts
@@ -1,0 +1,23 @@
+import { IUploadBase, IUploadDone } from '@ever-co/shared-utils';
+import { IUploaderStrategy } from '../../../models/uploader-strategy.interface';
+import { ResponseHandler } from './response.handler';
+
+export class DefaultResponseHandler extends ResponseHandler<
+  IUploadDone,
+  IUploadBase
+> {
+  protected canHandle(_: IUploaderStrategy): boolean {
+    return true; // Handles all remaining cases
+  }
+
+  protected transform(response: IUploadDone): IUploadBase {
+    const { itemId, result } = response;
+
+    return {
+      id: itemId,
+      remoteUrl: result.fullUrl,
+      remoteId: result.id,
+      uploadedAt: result.recordedAt,
+    };
+  }
+}

--- a/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/ever-rec-response.handler.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/ever-rec-response.handler.ts
@@ -1,0 +1,28 @@
+import { IUploadBase, IUploadDone } from '@ever-co/shared-utils';
+import { IUploaderStrategy } from '../../../models/uploader-strategy.interface';
+import { EverRecUploaderStrategy } from '../../../strategies/ever-rec.uploader';
+import { ResponseHandler } from './response.handler';
+
+export class EverRecResponseHandler extends ResponseHandler<
+  IUploadDone,
+  IUploadBase
+> {
+  protected canHandle(strategy: IUploaderStrategy): boolean {
+    return strategy instanceof EverRecUploaderStrategy;
+  }
+
+  protected transform(response: IUploadDone): IUploadBase {
+    const { itemId, result } = response;
+    const {
+      url: remoteUrl,
+      dbData: { id: remoteId, created: uploadedAt },
+    } = result as any;
+
+    return {
+      id: itemId,
+      remoteUrl,
+      remoteId,
+      uploadedAt,
+    };
+  }
+}

--- a/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/ever-rec-response.handler.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/ever-rec-response.handler.ts
@@ -1,7 +1,15 @@
-import { IUploadBase, IUploadDone } from '@ever-co/shared-utils';
+import { IRemoteUpload, IUploadBase, IUploadDone } from '@ever-co/shared-utils';
 import { IUploaderStrategy } from '../../../models/uploader-strategy.interface';
 import { EverRecUploaderStrategy } from '../../../strategies/ever-rec.uploader';
 import { ResponseHandler } from './response.handler';
+
+interface IEverRecUploadResult extends IRemoteUpload {
+  url: string;
+  dbData: {
+    id: string;
+    created: string;
+  };
+}
 
 export class EverRecResponseHandler extends ResponseHandler<
   IUploadDone,
@@ -16,7 +24,7 @@ export class EverRecResponseHandler extends ResponseHandler<
     const {
       url: remoteUrl,
       dbData: { id: remoteId, created: uploadedAt },
-    } = result as any;
+    } = result as IEverRecUploadResult;
 
     return {
       id: itemId,

--- a/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/ever-rec-response.handler.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/ever-rec-response.handler.ts
@@ -26,6 +26,12 @@ export class EverRecResponseHandler extends ResponseHandler<
       dbData: { id: remoteId, created: uploadedAt },
     } = result as IEverRecUploadResult;
 
+    if (!remoteUrl || !remoteId) {
+      throw new Error(
+        'Invalid EverRec upload response: missing required fields',
+      );
+    }
+
     return {
       id: itemId,
       remoteUrl,

--- a/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/response.handler.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/synchronize/handlers/response.handler.ts
@@ -1,0 +1,28 @@
+import { IUploaderStrategy } from '../../../models/uploader-strategy.interface';
+
+export abstract class ResponseHandler<TRequest, TResponse> {
+  protected nextHandler: ResponseHandler<TRequest, TResponse> | null = null;
+
+  setNext(
+    handler: ResponseHandler<TRequest, TResponse>,
+  ): ResponseHandler<TRequest, TResponse> {
+    this.nextHandler = handler;
+    return handler;
+  }
+
+  // Template method with chain logic
+  public handle(strategy: IUploaderStrategy, response: TRequest): TResponse {
+    if (this.canHandle(strategy)) {
+      return this.transform(response);
+    }
+
+    if (this.nextHandler) {
+      return this.nextHandler.handle(strategy, response);
+    }
+
+    throw new Error('No handler available to process the request');
+  }
+
+  protected abstract canHandle(strategy: IUploaderStrategy): boolean;
+  protected abstract transform(response: TRequest): TResponse;
+}

--- a/libs/electron/utils/src/lib/services/uploader/services/synchronize/synchronize.factory.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/synchronize/synchronize.factory.ts
@@ -1,0 +1,21 @@
+import { IUploadBase, IUploadDone } from '@ever-co/shared-utils';
+import { IUploaderStrategy } from '../../models/uploader-strategy.interface';
+import { DefaultResponseHandler } from './handlers/default-response.handler';
+import { EverRecResponseHandler } from './handlers/ever-rec-response.handler';
+import { ResponseHandler } from './handlers/response.handler';
+
+export class SynchronizeFactory {
+  private readonly chain: ResponseHandler<IUploadDone, IUploadBase>;
+
+  constructor() {
+    this.chain = new EverRecResponseHandler();
+    this.chain.setNext(new DefaultResponseHandler());
+  }
+
+  public synchronize(
+    strategy: IUploaderStrategy,
+    response: IUploadDone,
+  ): IUploadBase {
+    return this.chain.handle(strategy, response);
+  }
+}

--- a/libs/electron/utils/src/lib/services/uploader/services/video-uploader.service.ts
+++ b/libs/electron/utils/src/lib/services/uploader/services/video-uploader.service.ts
@@ -37,18 +37,12 @@ export class VideoUploaderService extends UploaderService<IVideo> {
     }));
   }
 
-  protected override async synchronize({
-    itemId,
-    result,
-  }: IUploadDone): Promise<void> {
+  protected override async synchronize(uploaded: IUploadDone): Promise<void> {
     await Promise.all([
-      this.service.update(itemId, { synced: true }),
-      this.service.saveUpload<IVideoUpload>({
-        id: itemId,
-        remoteUrl: result.fullUrl,
-        remoteId: result.id,
-        uploadedAt: result.recordedAt,
-      }),
+      this.service.update(uploaded.itemId, { synced: true }),
+      this.service.saveUpload<IVideoUpload>(
+        this.synchronizeFactory.synchronize(this.context.strategy, uploaded),
+      ),
     ]);
   }
 }

--- a/libs/electron/utils/src/lib/services/uploader/strategies/ever-rec.uploader.ts
+++ b/libs/electron/utils/src/lib/services/uploader/strategies/ever-rec.uploader.ts
@@ -1,0 +1,32 @@
+import { IUpload } from '@ever-co/shared-utils';
+import { EverRecService } from '../../ever-rec/ever-rec.service';
+import {
+  IUploaderConfig,
+  IUploaderStrategy,
+} from '../models/uploader-strategy.interface';
+
+export class EverRecUploaderStrategy implements IUploaderStrategy {
+  private readonly everRecService: EverRecService;
+
+  constructor(private readonly upload?: IUpload) {
+    this.everRecService = new EverRecService();
+  }
+
+  public config(): IUploaderConfig | null {
+    const url = this.everRecService.getUploadUrl(this.upload);
+
+    if (!url || !this.upload?.token) {
+      return null;
+    }
+
+    console.error('Danger', url, this.upload);
+
+    return {
+      url,
+      token: this.upload.token,
+      refreshToken: this.upload.refreshToken,
+      organizationId: null,
+      tenantId: null,
+    };
+  }
+}

--- a/libs/electron/utils/src/lib/services/uploader/strategies/ever-rec.uploader.ts
+++ b/libs/electron/utils/src/lib/services/uploader/strategies/ever-rec.uploader.ts
@@ -19,8 +19,6 @@ export class EverRecUploaderStrategy implements IUploaderStrategy {
       return null;
     }
 
-    console.error('Danger', url, this.upload);
-
     return {
       url,
       token: this.upload.token,

--- a/libs/electron/utils/src/lib/services/uploader/uploader-strategy.factory.ts
+++ b/libs/electron/utils/src/lib/services/uploader/uploader-strategy.factory.ts
@@ -1,0 +1,19 @@
+import { IUpload, IS3Config, isObjectEmpty } from '@ever-co/shared-utils';
+import { S3UploaderStrategy } from './strategies/s3.uploader';
+import { GauzyUploaderStrategy } from './strategies/gauzy.uploader';
+import { IUploaderStrategy } from './models/uploader-strategy.interface';
+import { EverRecUploaderStrategy } from './strategies/ever-rec.uploader';
+
+export class UploaderStrategyFactory {
+  public create(upload: IUpload, s3Config?: IS3Config): IUploaderStrategy {
+    if (s3Config && s3Config.enabled && !isObjectEmpty(s3Config)) {
+      return new S3UploaderStrategy(s3Config, upload.type);
+    }
+
+    if (upload.token && upload.apiUrl) {
+      return new EverRecUploaderStrategy(upload);
+    }
+
+    return new GauzyUploaderStrategy(upload.type);
+  }
+}

--- a/libs/shared/utils/src/lib/interfaces/storage.interface.ts
+++ b/libs/shared/utils/src/lib/interfaces/storage.interface.ts
@@ -1,6 +1,7 @@
 import { FormControl } from '@angular/forms';
 
 export interface IS3Config {
+  enabled: boolean;
   accessKeyId: string;
   accessKeySecret: string;
   region: string;
@@ -15,6 +16,7 @@ export interface IS3ConfigForm {
   region: FormControl<string | null>;
   s3Bucket: FormControl<string | null>;
   s3Endpoint: FormControl<string | null>;
+  enabled: FormControl<boolean | null>;
 }
 
 export interface IUploadConfig {

--- a/libs/shared/utils/src/lib/interfaces/upload.interface.ts
+++ b/libs/shared/utils/src/lib/interfaces/upload.interface.ts
@@ -21,6 +21,9 @@ export interface IUpload {
   type: UploadType;
   key: string;
   ids: string[];
+  refreshToken?: string;
+  token?: string;
+  apiUrl?: string;
 }
 
 export interface IUploadProgress {

--- a/libs/shared/utils/src/lib/interfaces/upload.interface.ts
+++ b/libs/shared/utils/src/lib/interfaces/upload.interface.ts
@@ -36,9 +36,9 @@ export interface IUploadError {
   itemId: string;
 }
 
-export interface IUploadDone {
+export interface IUploadDone<T = unknown> {
   itemId: string;
-  result: IRemoteUpload;
+  result: IRemoteUpload<T>;
 }
 
 export interface IUploadableService<T = any, U = any> {
@@ -72,10 +72,11 @@ export interface IUploadBase extends IBase {
   uploadedAt?: string;
 }
 
-export interface IRemoteUpload {
+export interface IRemoteUpload<T = unknown> {
   fullUrl: string;
   id: string;
   recordedAt: string;
+  data?: T;
 }
 
 export interface IVideoUpload extends IUploadBase {

--- a/libs/web/settings/data-access/src/lib/+state/storage-setting/storage-setting.reducer.ts
+++ b/libs/web/settings/data-access/src/lib/+state/storage-setting/storage-setting.reducer.ts
@@ -26,6 +26,7 @@ const initialState: IStorageState = {
     region: '',
     s3Bucket: '',
     s3Endpoint: '',
+    enabled: false,
     autoSync: false,
   },
   used: {

--- a/libs/web/settings/features/src/lib/aws-storage/aws-storage.component.html
+++ b/libs/web/settings/features/src/lib/aws-storage/aws-storage.component.html
@@ -2,113 +2,81 @@
   <!-- Aws Access Key ID Input -->
   <mat-form-field appearance="outline" class="w-full">
     <mat-label>Access Key ID</mat-label>
-    <input
-      matInput
-      type="text"
-      id="accessKeyId"
-      formControlName="accessKeyId"
-      placeholder="Enter aws access key ID"
-      type="password"
-      />
+    <input matInput type="text" id="accessKeyId" formControlName="accessKeyId" placeholder="Enter aws access key ID"
+      type="password" />
     @if (
-      form.controls['accessKeyId'].invalid &&
-      form.controls['accessKeyId'].touched
-      ) {
-      <mat-error
-        >
-        Aws access key ID is required.
-      </mat-error>
+    form.controls['accessKeyId'].invalid &&
+    form.controls['accessKeyId'].touched
+    ) {
+    <mat-error>
+      Aws access key ID is required.
+    </mat-error>
     }
   </mat-form-field>
 
   <!-- Aws Access Key Secret Input -->
   <mat-form-field appearance="outline" class="w-full">
     <mat-label>Access Key Secret</mat-label>
-    <input
-      matInput
-      type="password"
-      id="accessKeySecret"
-      formControlName="accessKeySecret"
-      placeholder="Enter aws access key Secret"
-      />
+    <input matInput type="password" id="accessKeySecret" formControlName="accessKeySecret"
+      placeholder="Enter aws access key Secret" />
     @if (
-      form.controls['accessKeySecret'].invalid &&
-      form.controls['accessKeySecret'].touched
-      ) {
-      <mat-error
-        >
-        Aws access key secret is required.
-      </mat-error>
+    form.controls['accessKeySecret'].invalid &&
+    form.controls['accessKeySecret'].touched
+    ) {
+    <mat-error>
+      Aws access key secret is required.
+    </mat-error>
     }
   </mat-form-field>
 
   <!-- Aws Region Input -->
   <mat-form-field appearance="outline" class="w-full">
     <mat-label>AWS Region</mat-label>
-    <input
-      matInput
-      type="text"
-      id="region"
-      formControlName="region"
-      placeholder="Enter aws region"
-      />
+    <input matInput type="text" id="region" formControlName="region" placeholder="Enter aws region" />
     @if (form.controls['region'].invalid && form.controls['region'].touched) {
-      <mat-error
-        >
-        Aws region is required.
-      </mat-error>
+    <mat-error>
+      Aws region is required.
+    </mat-error>
     }
   </mat-form-field>
 
   <!-- Aws S3 Bucket Input -->
   <mat-form-field appearance="outline" class="w-full">
     <mat-label>S3 Bucket Name</mat-label>
-    <input
-      matInput
-      type="text"
-      id="s3Bucket"
-      formControlName="s3Bucket"
-      placeholder="Enter S3 bucket name"
-      />
+    <input matInput type="text" id="s3Bucket" formControlName="s3Bucket" placeholder="Enter S3 bucket name" />
     @if (
-      form.controls['s3Bucket'].invalid && form.controls['s3Bucket'].touched
-      ) {
-      <mat-error
-        >
-        Aws S3 Bucket name is required.
-      </mat-error>
+    form.controls['s3Bucket'].invalid && form.controls['s3Bucket'].touched
+    ) {
+    <mat-error>
+      Aws S3 Bucket name is required.
+    </mat-error>
     }
   </mat-form-field>
 
   <!-- Aws S3 Bucket Endpoint Input -->
   <mat-form-field appearance="outline" class="w-full">
     <mat-label>S3 Bucket Endpoint</mat-label>
-    <input
-      matInput
-      type="url"
-      id="s3Endpoint"
-      formControlName="s3Endpoint"
-      placeholder="Enter s3 endpoint"
-      />
+    <input matInput type="url" id="s3Endpoint" formControlName="s3Endpoint" placeholder="Enter s3 endpoint" />
     @if (
-      form.controls['s3Endpoint'].touched &&
-      form.controls['s3Endpoint'].hasError('invalidUrl')
-      ) {
-      <mat-error
-        >
-        This endpoint URL is not valid.
-      </mat-error>
+    form.controls['s3Endpoint'].touched &&
+    form.controls['s3Endpoint'].hasError('invalidUrl')
+    ) {
+    <mat-error>
+      This endpoint URL is not valid.
+    </mat-error>
     }
   </mat-form-field>
 
+  <!-- Auto sync -->
+  <div class="start flex justify-between items-center mb-3">
+    <span class="text-gray-700">Enable S3 cloud sync</span>
+    <mat-slide-toggle formControlName="enabled">
+    </mat-slide-toggle>
+  </div>
+
   <!-- Submit and Cancel Buttons -->
   <div class="flex space-x-4">
-    <button
-      mat-stroked-button
-      color="primary"
-      type="submit"
-      [disabled]="form.invalid"
-      >
+    <button mat-stroked-button color="primary" type="submit" [disabled]="form.invalid">
       Save
     </button>
   </div>

--- a/libs/web/settings/features/src/lib/aws-storage/aws-storage.component.html
+++ b/libs/web/settings/features/src/lib/aws-storage/aws-storage.component.html
@@ -2,8 +2,8 @@
   <!-- Aws Access Key ID Input -->
   <mat-form-field appearance="outline" class="w-full">
     <mat-label>Access Key ID</mat-label>
-    <input matInput type="text" id="accessKeyId" formControlName="accessKeyId" placeholder="Enter aws access key ID"
-      type="password" />
+    <input matInput type="password" id="accessKeyId" formControlName="accessKeyId"
+      placeholder="Enter aws access key ID" />
     @if (
     form.controls['accessKeyId'].invalid &&
     form.controls['accessKeyId'].touched

--- a/libs/web/settings/features/src/lib/aws-storage/aws-storage.component.ts
+++ b/libs/web/settings/features/src/lib/aws-storage/aws-storage.component.ts
@@ -21,16 +21,16 @@ import { Store } from '@ngrx/store';
 import { Subject, takeUntil, tap } from 'rxjs';
 
 @Component({
-    selector: 'lib-aws-storage',
-    imports: [
+  selector: 'lib-aws-storage',
+  imports: [
     MatFormFieldModule,
     MatInputModule,
     ReactiveFormsModule,
     MatButtonModule,
     MatSlideToggleModule
-],
-    templateUrl: './aws-storage.component.html',
-    styleUrl: './aws-storage.component.scss'
+  ],
+  templateUrl: './aws-storage.component.html',
+  styleUrl: './aws-storage.component.scss'
 })
 export class AwsStorageComponent implements OnInit, OnDestroy {
   public form!: FormGroup;
@@ -46,6 +46,7 @@ export class AwsStorageComponent implements OnInit, OnDestroy {
       region: new FormControl('', [Validators.required]),
       s3Endpoint: new FormControl('', [urlValidator()]),
       s3Bucket: new FormControl('', [Validators.required]),
+      enabled: new FormControl(false)
     });
   }
   ngOnInit(): void {

--- a/libs/web/upload/data-access/src/lib/services/upload.service.ts
+++ b/libs/web/upload/data-access/src/lib/services/upload.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { selectClaimsToken, selectToken } from '@ever-co/auth-data-access';
+import { selectClaimsToken } from '@ever-co/auth-data-access';
 import { ElectronService } from '@ever-co/electron-data-access';
 import { REC_ENV } from '@ever-co/shared-service';
 import {
@@ -27,13 +27,14 @@ export class UploadService {
     private readonly store: Store,
     @Inject(REC_ENV)
     private readonly environment: IEnvironment,
-  ) {}
+  ) { }
 
   public upload(upload: IUpload): Observable<void> {
     return this.store.select(selectSettingStorageState).pipe(
       take(1),
       filter(({ uploadConfig }) => uploadConfig.autoSync),
       withLatestFrom(this.store.select(selectClaimsToken)),
+      filter(([, claims]) => !!claims),
       map(([{ s3Config }, claims]) =>
         this.electronService.send(Channel.UPLOAD, {
           upload: {


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issues.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Previous screenshots

Please add here videos or images of the previous status

## Current screenshots

Please add here videos or images of the current (new) status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Enable S3 cloud sync” toggle in storage settings.
  - New EverRec upload option and API URL support.
  - Uploads now include token and optional refresh token when available.

- **Improvements**
  - Unified upload synchronization across media types via a handler chain.
  - Strategy factory selects appropriate uploader automatically.
  - Upload payload now includes environment API URL and claim tokens.

- **UI**
  - Streamlined AWS S3 form layout with inline validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->